### PR TITLE
Improve touch and feel with UIRefreshControl

### DIFF
--- a/Sources/RefreshableScrollView/RefreshableScrollView.swift
+++ b/Sources/RefreshableScrollView/RefreshableScrollView.swift
@@ -33,8 +33,8 @@ public struct RefreshableScrollView: UIViewRepresentable {
                 }
             } else {
                 let refreshControl = UIRefreshControl()
+                refreshControl.addTarget(context.coordinator, action: #selector(Coordinator.handleRefreshControl), for: .valueChanged)
                 scrollView.refreshControl = refreshControl
-                scrollView.delegate = context.coordinator
             }
         }
     }
@@ -58,22 +58,15 @@ public struct RefreshableScrollView: UIViewRepresentable {
         
         var isRefreshing: Binding<Bool>
         var action: (() -> Void)?
-        private var offset: CGFloat = 0
-        
+
         init(_ isRefreshing: Binding<Bool>, action: (() -> Void)?) {
             self.isRefreshing = isRefreshing
             self.action = action
         }
-        
-        public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-            if isRefreshing.wrappedValue {
-                return
-            }
-            if offset - scrollView.contentOffset.y < 40 {
-                return
-            }
+
+        @objc fileprivate func handleRefreshControl() {
             isRefreshing.wrappedValue = true
-            self.action?()
+            action?()
         }
     }
 }


### PR DESCRIPTION
fixed #1 
Modify logic for firing refresh action using UIRefreshControl's valueChanged event.
It makes the gesture like preinstalled apps.

## Result
https://user-images.githubusercontent.com/202968/216654790-c7ad45d7-8392-410c-bbbc-a90e00a912e7.mov